### PR TITLE
fix: don't use bullets for alphanumeric lists

### DIFF
--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -170,7 +170,8 @@ local function get_ts_positions(bufnr, start_row, end_row, root)
     "org",
     [[
       (stars) @stars
-      (bullet) @bullet
+      ((bullet) @bullet
+        (#match? @bullet "[-\*\+]"))
 
       (listitem . (bullet) . (paragraph .
         (expr "[" "str" @_org_checkbox_check "]") @org_checkbox_done


### PR DESCRIPTION
Currently, all bullets get replaced with the `•` unicode char. But for alphabet and number lists, that should not happen.
I added a check into the treesitter query to only return `-`, `*`, and `+` bullets.

Here is how it looks with the PR:
![Screen Capture_select-area_20220630104416](https://user-images.githubusercontent.com/12900252/176575143-d072755e-34a6-45f1-9312-923943f9dca8.png)
![Screen Capture_select-area_20220630104349](https://user-images.githubusercontent.com/12900252/176575152-824d2bb3-380a-422e-a926-c610157bec90.png)

