### PR TITLE
fix: update checkbox bullets to match new grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ use {"akinsho/org-bullets.nvim", config = function()
         return default_list
       end,
       checkboxes = {
-        cancelled = { "", "OrgCancelled" },
+        half = { "", "OrgTSCheckboxHalfChecked" },
         done = { "✓", "OrgDone" },
         todo = { "˟", "OrgTODO" },
       },

--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -149,7 +149,7 @@ local function get_ts_positions(bufnr, start_row, end_row, root)
 
       (checkbox "[ ]") @org_checkbox
       (checkbox status: (expr "str") @_org_checkbox_done_str (#any-of? @_org_checkbox_done_str "x" "X")) @org_checkbox_done
-      (checkbox status: (expr "-")) @org_checkbox_cancelled
+      (checkbox status: (expr "-")) @org_checkbox_half
     ]]
   )
   for _, match, _ in query:iter_matches(root, bufnr, start_row, end_row) do


### PR DESCRIPTION
Proper checkbox support was added to the ts org grammar, so there is no need to have a hack around it any more.