### PR TITLE
feat: add separate highlight groups for bullet points

### DIFF
--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -6,10 +6,14 @@ local NAMESPACE = api.nvim_create_namespace("org-bullets")
 local org_headline_hl = "OrgHeadlineLevel"
 
 local list_groups = {
-  ["-"] = "OrgHeadlineLevel1",
-  ["+"] = "OrgHeadlineLevel2",
-  ["*"] = "OrgHeadlineLevel3",
+  ["-"] = "OrgBulletsDash",
+  ["+"] = "OrgBulletsPlus",
+  ["*"] = "OrgBulletsStar",
 }
+
+vim.api.nvim_set_hl(0, 'OrgBulletsDash', { link = 'OrgHeadlineLevel1'})
+vim.api.nvim_set_hl(0, 'OrgBulletsPlus', { link = 'OrgHeadlineLevel2'})
+vim.api.nvim_set_hl(0, 'OrgBulletsStar', { link = 'OrgHeadlineLevel3'})
 
 ---@class BulletsConfig
 ---@field public show_current_line boolean


### PR DESCRIPTION
Hi there! First time contributing here, so let me know if there's something else I need to do or anything like that :)

I wanted to define separate highlight groups so that the colours of the bullets could be changed independently of the colours of the headings. Right now, the `-` is coloured by `OrgHeadlineLevel1`, `+` by Level2, etc. 

After the change, it defaults to the colour of the bullet by itself, until overridden in your config