### PR TITLE
conf parameter is optional

### DIFF
--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -227,7 +227,7 @@ end
 
 local ticks = {}
 ---Save the user config and initialise the plugin
----@param conf BulletsConfig
+---@param conf? BulletsConfig
 function M.setup(conf)
   conf = conf or {}
   set_highlights()


### PR DESCRIPTION
Got rid of warning that conf is an optional parameter