### PR TITLE
feat: Add option to disable specific symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ use {"akinsho/org-bullets.nvim", config = function()
         table.insert(default_list, "♥")
         return default_list
       end,
+      -- or false to disable the symbol. Works for all symbols
+      headlines = false,
       checkboxes = {
         half = { "", "OrgTSCheckboxHalfChecked" },
         done = { "✓", "OrgDone" },

--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -11,12 +11,15 @@ local list_groups = {
   ["*"] = "OrgBulletsStar",
 }
 
+---@class OrgBulletsSymbols
+---@field list? string | false
+---@field headlines? string[] | function(symbols: string[]) | false
+---@field checkboxes? table<'half' | 'done' | 'todo', string[]> | false
+
 ---@class BulletsConfig
----@field public show_current_line boolean
----@field public symbols string[] | function(symbols: string[]): string[]
----@field public indent boolean
+---@field public symbols OrgBulletsSymbols
+---@field public indent? boolean
 local defaults = {
-  show_current_line = false,
   symbols = {
     list = "•",
     headlines = { "◉", "○", "✸", "✿" },
@@ -67,6 +70,9 @@ local markers = {
   stars = function(str, conf)
     local level = #str <= 0 and 0 or #str
     local symbols = conf.symbols.headlines
+    if not symbols then
+      return false
+    end
     local symbol = add_symbol_padding((symbols[level] or symbols[1]), level, conf.indent)
     local highlight = org_headline_hl .. level
     return { { symbol, highlight } }
@@ -74,6 +80,9 @@ local markers = {
   -- Checkboxes [x]
   checkbox = function(str, conf)
     local symbols = conf.symbols.checkboxes
+    if not symbols then
+      return false
+    end
     local text = symbols.todo
     if str:match("[Xx]") then
       text = symbols.done
@@ -84,7 +93,11 @@ local markers = {
   end,
   -- List bullets *,+,-
   bullet = function(str, conf)
-    local symbol = add_symbol_padding(conf.symbols.list, (#str - 1), true)
+    local symbols = conf.symbols.list
+    if not symbols then
+      return false
+    end
+    local symbol = add_symbol_padding(symbols, (#str - 1), true)
     return { { symbol, list_groups[vim.trim(str)] } }
   end,
 }


### PR DESCRIPTION
Add an ability to disable adding marks for symbols by setting it to `false`.
Also, tweak annotation docs to properly reflect the structure.

I'm suggesting this because we recently added experimental support for virtual indents on Orgmode, but there are issues with list items when it is at column 0. It looks like a Neovim issue and I'll probably report it, but still this is a good option to have.

This is the issue I'm talking about:
![screenshot_2024_02_18_11_33_00](https://github.com/akinsho/org-bullets.nvim/assets/1782860/7e21b965-fa06-400d-9860-70fd7ba554c4)


