### PR TITLE
fix: Handle false marker

### DIFF
--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -110,6 +110,10 @@ local markers = {
 ---@param end_col integer
 ---@param highlight string?
 local function set_mark(bufnr, virt_text, lnum, start_col, end_col, highlight)
+  if not virt_text then
+    return
+  end
+
   local ok, result = pcall(api.nvim_buf_set_extmark, bufnr, NAMESPACE, lnum, start_col, {
     end_col = end_col,
     hl_group = highlight,


### PR DESCRIPTION
In https://github.com/akinsho/org-bullets.nvim/pull/36 I forgot to ignore the `false` marker.
This fixes it.

Edit: Would you be ok if we move this plugin under `nvim-orgmode` organization?