### PR TITLE
added wrap for headline icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ use {"akinsho/org-bullets.nvim", config = function()
   require("org-bullets").setup {
     concealcursor = false, -- If false then when the cursor is on a line underlying characters are visible
     symbols = {
+      -- default: do not repeat the headlines list. use first icon only after all used once.
+      wrap = false,
       -- list symbol
       list = "•",
       -- headlines can be a list

--- a/lua/org-bullets.lua
+++ b/lua/org-bullets.lua
@@ -21,6 +21,7 @@ local list_groups = {
 ---@field public indent? boolean
 local defaults = {
   symbols = {
+    wrap = false,
     list = "•",
     headlines = { "◉", "○", "✸", "✿" },
     checkboxes = {
@@ -73,7 +74,13 @@ local markers = {
     if not symbols then
       return false
     end
-    local symbol = add_symbol_padding((symbols[level] or symbols[1]), level, conf.indent)
+    local symbol
+    if not conf.symbols.wrap then
+      symbol = add_symbol_padding((symbols[level] or symbols[1]), level, conf.indent)
+    else
+      local symbolIndex = ((level - 1) % #symbols) + 1
+      symbol = add_symbol_padding(symbols[symbolIndex], level, conf.indent)
+    end
     local highlight = org_headline_hl .. level
     return { { symbol, highlight } }
   end,


### PR DESCRIPTION
added new option  `symbols.wrap` with default `false` to not break existing users experience.

if `true` setting wraps headline icons around list length for any level `n` icon `n mod #symbols` is used.